### PR TITLE
Check environment type for Vite dev server check

### DIFF
--- a/src/Assets/ViteCompiler.php
+++ b/src/Assets/ViteCompiler.php
@@ -28,6 +28,10 @@ class ViteCompiler extends Compiler
 
     public function isDevServerRunning(): bool
     {
+        if(! in_array(wp_get_environment_type(), ['local', 'development'])) {
+            return false;
+        }
+
         $args = [];
 
         if($this->ssl) {


### PR DESCRIPTION
With this PR we only check if Vite dev server is running is environment type is `local` or `development`.

Addressing:

https://github.com/tailpress/tailpress/discussions/288

https://github.com/tailpress/tailpress/discussions/288